### PR TITLE
use http for bintray source

### DIFF
--- a/devel/Dockerfile.template
+++ b/devel/Dockerfile.template
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main @IMAGE_SUITE@ main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main @IMAGE_SUITE@ main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/amd64/Dockerfile
+++ b/devel/amd64/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/arm64/Dockerfile
+++ b/devel/arm64/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/armel/Dockerfile
+++ b/devel/armel/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/armhf/Dockerfile
+++ b/devel/armhf/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/i386/Dockerfile
+++ b/devel/i386/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/mips/Dockerfile
+++ b/devel/mips/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/mips64el/Dockerfile
+++ b/devel/mips64el/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/mipsel/Dockerfile
+++ b/devel/mipsel/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/ppc64el/Dockerfile
+++ b/devel/ppc64el/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.

--- a/devel/s390x/Dockerfile
+++ b/devel/s390x/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -qq \
 		google-mock \
 		libgtest-dev
 
-RUN (echo "deb [allow-insecure=yes] https://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
+RUN (echo "deb [allow-insecure=yes] http://dl.bintray.com/laarid/main stretch main" | tee /etc/apt/sources.list.d/bintray.list) \
 	&& apt-get update -qq
 
 # Cannot fetch key on mips/mipsel.


### PR DESCRIPTION
It seems bintray has various problems in deb hosting, and now it comes
to https. This change replaces https with http in binary source line.

Closes: #2